### PR TITLE
Always get default store regardless of name

### DIFF
--- a/code/community/Codisto/Sync/Model/Sync.php
+++ b/code/community/Codisto/Sync/Model/Sync.php
@@ -204,7 +204,7 @@ class Codisto_Sync_Model_Sync
 
 	public function UpdateCategory($syncDb, $id)
 	{
-		$store = Mage::app()->getStore('default');
+		$store = Mage::app()->getStore(0);
 
 		$db = $this->GetSyncDb($syncDb);
 
@@ -240,7 +240,7 @@ class Codisto_Sync_Model_Sync
 
 	public function UpdateProducts($syncDb, $ids)
 	{
-		$store = Mage::app()->getStore('default');
+		$store = Mage::app()->getStore(0);
 
 		$db = $this->GetSyncDb($syncDb);
 
@@ -712,7 +712,7 @@ class Codisto_Sync_Model_Sync
 
 	public function SyncChunk($syncDb)
 	{
-		$store = Mage::app()->getStore('default');
+		$store = Mage::app()->getStore(0);
 
 		$db = $this->GetSyncDb($syncDb);
 


### PR DESCRIPTION
The following gets the default store if it's called 'default', which is the default, but often changed.
$store = Mage::app()->getStore('default'); 

The following gets the default store regardless of what it's called:
$store = Mage::app()->getStore(0);