### PR TITLE
make sync more robust

### DIFF
--- a/code/community/Codisto/Sync/Model/Sync.php
+++ b/code/community/Codisto/Sync/Model/Sync.php
@@ -750,7 +750,7 @@ class Codisto_Sync_Model_Sync
 		$this->currentEntityId = $orderData['entity_id'];
 	}
 
-	public function SyncChunk($syncDb, $storeId)
+	public function SyncChunk($syncDb, $configurableCount, $simpleCount, $storeId)
 	{
 		$store = Mage::app()->getStore($storeId);
 
@@ -851,7 +851,7 @@ class Codisto_Sync_Model_Sync
 								->addAttributeToFilter('type_id', array('eq' => 'configurable'))
 								->addAttributeToFilter('entity_id', array('gt' => $this->currentEntityId));
 
-			$configurableProducts->getSelect()->order('entity_id')->limit(6);
+			$configurableProducts->getSelect()->order('entity_id')->limit($configurableCount);
 			$configurableProducts->setOrder('entity_id', 'ASC');
 
 			Mage::getSingleton('core/resource_iterator')->walk($configurableProducts->getSelect(), array(array($this, 'SyncConfigurableProductData')), array( 'type' => 'configurable', 'db' => $db, 'preparedStatement' => $insertProduct, 'preparedskuStatement' => $insertSKU, 'preparedskumatrixStatement' => $insertSKUMatrix, 'preparedcategoryproductStatement' => $insertCategoryProduct, 'preparedimageStatement' => $insertImage, 'preparedskuimageStatement' => $insertSKUImage, 'preparedproductoptionStatement' => $insertProductOption,  'preparedproductoptionvalueStatement' => $insertProductOptionValue, 'preparedproducthtmlStatement' => $insertProductHTML, 'preparedattributeStatement' => $insertAttribute, 'preparedproductattributeStatement' => $insertProductAttribute, 'store' => $store ));
@@ -878,7 +878,7 @@ class Codisto_Sync_Model_Sync
 								->addAttributeToFilter('type_id', array('eq' => 'simple'))
 								->addAttributeToFilter('entity_id', array('gt' => $this->currentEntityId));
 
-			$simpleProducts->getSelect()->where('`e`.entity_id NOT IN (SELECT product_id FROM '.$superLinkName.')')->order('entity_id')->limit(250);
+			$simpleProducts->getSelect()->where('`e`.entity_id NOT IN (SELECT product_id FROM '.$superLinkName.')')->order('entity_id')->limit($simpleCount);
 			$simpleProducts->setOrder('entity_id', 'ASC');
 
 			Mage::getSingleton('core/resource_iterator')->walk($simpleProducts->getSelect(), array(array($this, 'SyncSimpleProductData')), array( 'type' => 'simple', 'db' => $db, 'preparedStatement' => $insertProduct, 'preparedcategoryproductStatement' => $insertCategoryProduct, 'preparedimageStatement' => $insertImage, 'preparedproducthtmlStatement' => $insertProductHTML, 'preparedattributeStatement' => $insertAttribute, 'preparedproductattributeStatement' => $insertProductAttribute, 'store' => $store ));
@@ -942,20 +942,6 @@ class Codisto_Sync_Model_Sync
 		{
 			return 'pending';
 		}
-	}
-
-	public function Sync($syncDb, $storeId)
-	{
-		ini_set('max_execution_time', -1);
-
-		$result = $this->SyncChunk($syncDb, $storeId);
-		while($result != 'complete')
-		{
-			$result = $this->SyncChunk($syncDb, $storeId);
-		}
-
-		$this->SyncTax($syncDb, $storeId);
-		$this->SyncStores($syncDb, $storeId);
 	}
 
 	public function SyncTax($syncDb, $storeId)

--- a/code/community/Codisto/Sync/controllers/IndexController.php
+++ b/code/community/Codisto/Sync/controllers/IndexController.php
@@ -24,6 +24,9 @@ class Codisto_Sync_IndexController extends Codisto_Sync_Controller_BaseControlle
 
 	public function calcAction()
 	{
+		set_time_limit(0);
+		ignore_user_abort(false);
+
 		$request = $this->getRequest();
 		$response = $this->getResponse();
 
@@ -127,6 +130,9 @@ class Codisto_Sync_IndexController extends Codisto_Sync_Controller_BaseControlle
 
 	public function indexAction()
 	{
+		set_time_limit(0);
+		ignore_user_abort(false);
+
 		$request = $this->getRequest();
 		$method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
 		$contenttype = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';

--- a/code/community/Codisto/Sync/controllers/SyncController.php
+++ b/code/community/Codisto/Sync/controllers/SyncController.php
@@ -821,8 +821,6 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 		header('Content-Disposition: attachment; filename=' . basename($syncDb));
 		header('Content-Length: ' . filesize($syncDb));
 
-		if(ob_get_contents())
-			ob_clean();
 		if(ob_get_level() > 0)
 			ob_end_clean();
 

--- a/code/community/Codisto/Sync/controllers/SyncController.php
+++ b/code/community/Codisto/Sync/controllers/SyncController.php
@@ -822,7 +822,10 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 		header('Content-Length: ' . filesize($syncDb));
 
 		if(ob_get_contents())
-		ob_clean();
+			ob_clean();
+		if(ob_get_level() > 0)
+			ob_end_clean();
+
 		flush();
 
 		readfile($syncDb);

--- a/code/community/Codisto/Sync/controllers/SyncController.php
+++ b/code/community/Codisto/Sync/controllers/SyncController.php
@@ -29,7 +29,7 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 	public function indexAction()
 	{
 		set_time_limit(0);
-		ignore_user_abort(false);
+		ignore_user_abort(true);
 
 		$response = $this->getResponse();
 		$request = $this->getRequest();
@@ -785,6 +785,7 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 
 	private function Send($syncDb)
 	{
+		ignore_user_abort(false);
 		ini_set('output_buffering', 0);
 		ini_set('zlib.output_compression', 0);
 

--- a/code/community/Codisto/Sync/controllers/SyncController.php
+++ b/code/community/Codisto/Sync/controllers/SyncController.php
@@ -26,6 +26,9 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 
 	public function indexAction()
 	{
+		set_time_limit(0);
+		ignore_user_abort(false);
+
 		$response = $this->getResponse();
 		$request = $this->getRequest();
 		$request->setDispatched(true);
@@ -814,6 +817,9 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 
 	private function Send($syncDb)
 	{
+		ini_set('output_buffering', 0);
+		ini_set('zlib.output_compression', 0);
+
 		header('Cache-Control: no-cache, must-revalidate'); //HTTP 1.1
 		header('Pragma: no-cache'); //HTTP 1.0
 		header('Expires: Thu, 01 Jan 1970 00:00:00 GMT'); // Date in the past
@@ -821,7 +827,7 @@ class Codisto_Sync_SyncController extends Codisto_Sync_Controller_BaseController
 		header('Content-Disposition: attachment; filename=' . basename($syncDb));
 		header('Content-Length: ' . filesize($syncDb));
 
-		if(ob_get_level() > 0)
+		while(ob_get_level() > 0)
 			ob_end_clean();
 
 		flush();


### PR DESCRIPTION
* disable output buffering when sending files
* disable time limits
* disable output buffering / zlib compression at php level
* make limits on the walk query dynamic based on input from the sync engine
* ensure ignore_user_abort is set correctly
* remove full Sync action