### PR TITLE
- Detect if zlib output compression is enabled. This fixes cases wher…

### DIFF
--- a/code/community/Codisto/Sync/Controller/Router.php
+++ b/code/community/Codisto/Sync/Controller/Router.php
@@ -397,7 +397,9 @@ class Codisto_Sync_Controller_Router extends Mage_Core_Controller_Varien_Router_
 
 				$curlOptions = array(CURLOPT_TIMEOUT => 60, CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0);
 				$acceptEncoding = $request->getHeader('Accept-Encoding');
-				if(!$acceptEncoding)
+				$zlibEnabled = strtoupper(ini_get('zlib.output_compression'));
+
+				if(!$acceptEncoding || ($zlibEnabled == 1 || $zlibEnabled == 'ON'))
 					$curlOptions[CURLOPT_ENCODING] = '';
 
 				// proxy request


### PR DESCRIPTION
…e we couldn't turn it off due to php.ini restrictions and as a result there was compression double handling ..