### PR TITLE
fix null attribute input

### DIFF
--- a/code/community/Codisto/Sync/Model/Sync.php
+++ b/code/community/Codisto/Sync/Model/Sync.php
@@ -835,6 +835,11 @@ class Codisto_Sync_Model_Sync
 							'source_model' => $attribute->getSourceModel()
 					);
 
+					if(!isset($attributeData['frontend_type']) || is_null($attributeData['frontend_type']))
+					{
+						$attributeData['frontend_type'] = '';
+					}
+
 					if($attributeData['source_model'])
 					{
 						if(isset($this->optionCache[$store->getId().'-'.$attribute->getId()]))


### PR DESCRIPTION
fixes:
EXECUTEFIRST - Exception: SQLSTATE[23000]: Integrity constraint violation: 19 Attribute.Input may not be NULL on line: 922 in file: app/code/community/Codisto/Sync/Model/Sync.php